### PR TITLE
fix: Add proper TypeScript type casting for event handlers in test page

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -65,8 +65,10 @@ export default function TestPage() {
             boxShadow: '0 4px 6px -1px rgba(5, 150, 105, 0.3)',
             transition: 'transform 0.2s',
           }}
-          onMouseOver={(e) => e.target.style.transform = 'translateY(-2px)'}
-          onMouseOut={(e) => e.target.style.transform = 'translateY(0)'}
+          onMouseOver={(e) => (e.target as HTMLElement).style.transform = 'translateY(-2px)'}
+          onMouseOut={(e) => (e.target as HTMLElement).style.transform = 'translateY(0)'}
+          onFocus={(e) => (e.target as HTMLElement).style.transform = 'translateY(-2px)'}
+          onBlur={(e) => (e.target as HTMLElement).style.transform = 'translateY(0)'}
           >
             💰 Get Started
           </button>
@@ -83,12 +85,20 @@ export default function TestPage() {
             transition: 'all 0.2s',
           }}
           onMouseOver={(e) => {
-            e.target.style.background = '#ecfdf5';
-            e.target.style.transform = 'translateY(-2px)';
+            (e.target as HTMLElement).style.background = '#ecfdf5';
+            (e.target as HTMLElement).style.transform = 'translateY(-2px)';
           }}
           onMouseOut={(e) => {
-            e.target.style.background = 'white';
-            e.target.style.transform = 'translateY(0)';
+            (e.target as HTMLElement).style.background = 'white';
+            (e.target as HTMLElement).style.transform = 'translateY(0)';
+          }}
+          onFocus={(e) => {
+            (e.target as HTMLElement).style.background = '#ecfdf5';
+            (e.target as HTMLElement).style.transform = 'translateY(-2px)';
+          }}
+          onBlur={(e) => {
+            (e.target as HTMLElement).style.background = 'white';
+            (e.target as HTMLElement).style.transform = 'translateY(0)';
           }}
           >
             🔐 Sign In


### PR DESCRIPTION
- Fix Property 'style' does not exist on type 'EventTarget' errors
- Add proper HTMLElement type casting for onMouseOver/onMouseOut handlers
- Add onFocus/onBlur handlers for accessibility compliance
- Resolves Vercel deployment TypeScript compilation errors